### PR TITLE
Update CuQuantumContractor based on cuquantum-python 25.03 deprecation

### DIFF
--- a/cotengra/contract.py
+++ b/cotengra/contract.py
@@ -849,14 +849,11 @@ class CuQuantumContractor:
         self.network = None
 
     def setup(self, *arrays):
-        from cuquantum import cutensornet as cutn
-        from cuquantum import Network, NetworkOptions
+        from cuquantum import Network
 
-        self.handle = cutn.create()
         self.network = Network(
             self.eq,
             *arrays,
-            options=NetworkOptions(handle=self.handle),
         )
         self.network.contract_path(**self.kwargs)
         if self.autotune:
@@ -882,12 +879,8 @@ class CuQuantumContractor:
         return self.network.contract()
 
     def __del__(self):
-        from cuquantum import cutensornet as cutn
-
         if self.network is not None:
             self.network.free()
-        if self.handle is not None:
-            cutn.destroy(self.handle)
 
 
 def make_contractor(

--- a/cotengra/contract.py
+++ b/cotengra/contract.py
@@ -849,7 +849,13 @@ class CuQuantumContractor:
         self.network = None
 
     def setup(self, *arrays):
-        from cuquantum import Network
+        import cuquantum
+        if hasattr(cuquantum, 'bindings'):
+            # cuquantum-python >= 25.03
+            from cuquantum.tensornet import Network
+        else:
+            # for cuquantum < 25.03
+            from cuquantum import Network
 
         self.network = Network(
             self.eq,


### PR DESCRIPTION
Starting `cuquantum-python==25.03`, the `cuquantum.Network` API is deprecated and these pythonic APIs are migrated under `cuquantum.tensornet` module. The deprecated APIs will remain functional for a few releases before being removed completely. Release notes can be found [here](https://docs.nvidia.com/cuda/cuquantum/latest/python/release-notes.html#cuquantum-python-v25-03-0).

This PR update `CuQuantumContractor` to use the new APIs. 
