### PR TITLE
Fix UnboundLocalError when an explicit backend is passed to Contractor (#83)

### DIFF
--- a/cotengra/contract.py
+++ b/cotengra/contract.py
@@ -743,7 +743,9 @@ class Contractor:
 
         if backend is None:
             backend = infer_backend_multi(*arrays)
-            xp = get_namespace(backend)
+        # resolve ``xp`` whether backend was inferred or passed explicitly,
+        # otherwise it is unbound below for an explicit backend (gh #83)
+        xp = get_namespace(backend)
 
         if implementation == "auto":
             if backend == "numpy":

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -115,6 +115,27 @@ def test_basic_equations(eq, dtype, strip_exponent):
     assert_allclose(x, y, rtol=rtol, atol=atol)
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # explicit backend reaching the autoray implementation
+        {"backend": "numpy", "implementation": "autoray"},
+        # explicit backend reaching the strip-exponent path
+        {"backend": "numpy", "strip_exponent": True},
+    ],
+)
+def test_explicit_backend_resolves_namespace(kwargs):
+    # a backend passed explicitly (not inferred) must still resolve ``xp``;
+    # it was previously left unbound, raising UnboundLocalError (gh #83)
+    eq = "ab,bc->ac"
+    arrays = ctg.utils.make_arrays_from_eq(eq, dtype="float64")
+    expected = np.einsum(eq, *arrays)
+    y = ctg.einsum(eq, *arrays, **kwargs)
+    if kwargs.get("strip_exponent"):
+        y = y[0] * 10 ** y[1]
+    assert_allclose(y, expected, rtol=5e-6, atol=1e-8)
+
+
 @pytest.mark.parametrize("n", [10])
 @pytest.mark.parametrize("d_min", [2])
 @pytest.mark.parametrize("d_max", [4])


### PR DESCRIPTION
Fixes #83.

`Contractor.__call__` only assigned `xp = get_namespace(backend)` inside the `if backend is None:` block, so when a `backend` is passed explicitly `xp` is left unbound. Any explicit, non-`numpy` backend then routes to the `autoray` implementation and reaches `_einsum = xp.einsum`, raising `UnboundLocalError` instead of contracting:

```python
import cotengra as ctg, numpy as np
ctg.einsum('ab,b->', np.random.rand(10, 5), np.random.rand(5), backend='ray')
# UnboundLocalError: cannot access local variable 'xp' ...
```

While fixing it I noticed the same unbound `xp` breaks a second path: with an explicit backend the `exponent`/`strip_exponent` handling at the end of the method uses `xp.max`/`xp.transpose`/`xp.log10`, which is reached even for the `cotengra` implementation. So e.g. `backend='numpy', strip_exponent=True` crashes too, not just the autoray case.

Fix: resolve `xp` once `backend` is known, whether it was inferred or supplied explicitly. That covers both paths with a single change.

Added `test_explicit_backend_resolves_namespace`, parametrized over the autoray-implementation and strip-exponent cases. It's numpy-only so it needs no extra backends installed; both cases fail on `main` and pass here, and the rest of `test_compute.py` (991 tests) stays green.

Happy to add a `changelog.md` entry if you'd like one — left it out since you curate that at release time.

Thanks to @nikplx for the clear report and the diagnosis.
